### PR TITLE
feat: [Import Assistant] Page transformations

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,88 @@ Powerful AI capabilities to simplify AEM import script development.
 
 ## Usage
 
-Coming soon
+Accessing the AEM Import Builder is achieved by using the `ImportBuilderFactory` to create an `ImportBuilder` instance.
+
+Visit the [aem-import-helper](https://github.com/adobe/aem-import-helper/blob/main/src/assistant/assistant-helper.js) for a full example of how to use the AEM Import Builder.
+
+### Import Builder Factory
+
+The `ImportBuilderFactory` is responsible for managing authentication and emitting events during builder operations.
+The `create` method of the factory returns an `ImportBuilder` instance that can be used to build an AEM import script.
+An `ImportBuilder` must be given a sample HTML document and screenshot to operate against. A set of existing import rules
+can also be provided when building on top of an existing project.
+
+```typescript
+import { ImportBuilderFactory } from 'aem-import-builder';
+
+const factory = ImportBuilderFactory({ auth, baseUrl });
+factory.on('start', (msg) => {
+  // start message
+});
+factory.on('progress', (msg) => {
+  // progress message
+});
+factory.on('complete', () => {
+  // complete message
+});
+
+// rules is in import rules JSON object
+// page is array containing an HTML document string and a Base64 encoded screenshot string
+const builder = factory.create({mode: 'script', rules, page});
+```
+
+### Import Builder
+
+An `ImportBuilder` consists of several asynchronous builder functions that all return a manifest of builder file items.
+The `BuilderManifest` is a list of files that can be used to create an AEM import script.
+
+```typescript
+export type BuilderFileItem = {
+  name: string;
+  type?: 'parser' | 'transformer';
+  contents: string;
+}
+```
+
+### Build Project
+
+Build a new import project that includes an initial import script and a set of import rules.
+
+```typescript
+const manifest = await builder.buildProject();
+```
+
+### Cleanup
+
+Add cleanup rules to the import rules that will remove unnecessary elements from the document being imported.
+
+```typescript
+const manifest = await builder.addCleanup('breadcrumbs');
+```
+
+### Blocks
+
+Add block rules to the import rules that will identify and extract blocks of content from the document being imported.
+
+```typescript
+const manifest = await builder.addBlock('block-name', 'block description');
+```
+
+### Block Cells
+
+Add a block cell parser script to the import project that will add content to a block.
+
+```typescript
+const manifest = await builder.addCellParser('block-name', 'description of cell content');
+```
+
+### Page Transformation
+
+Add a page transformation script to the import project that will transform the document content.
+
+```typescript
+const manifest = await builder.addPageTransformer('transformer-name', 'description of page transformation');
+```
 
 ## Developer Guide
 
@@ -16,6 +97,14 @@ Install all the dependencies.
 
 ```
 npm i
+```
+
+### Build
+
+This is a Typescript project so a build step is required to generate the final Javascript.
+
+```
+npm run build
 ```
 
 ### Lint
@@ -32,14 +121,6 @@ Run all the units tests using Mocha.
 
 ```
 npm run test
-```
-
-### Build
-
-This is a Typescript project so a build step is required to generate the final Javascript.
-
-```
-npm run build
 ```
 
 ### Environment

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "aem-import-rules": "^0.0.2",
+        "aem-import-rules": "^0.1.0",
         "events": "^3.3.0",
         "handlebars": "^4.7.8",
         "html-minifier-terser": "^7.2.0"
@@ -1285,9 +1285,9 @@
       }
     },
     "node_modules/aem-import-rules": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/aem-import-rules/-/aem-import-rules-0.0.2.tgz",
-      "integrity": "sha512-phR3cYPCRG0J6877z93Q/HY8/z8vxhrgeme7UBmsRWj7Fx+657xEqeRhE+tPzaHE76IVTR63tTAnQS4+A1pA0w==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/aem-import-rules/-/aem-import-rules-0.1.0.tgz",
+      "integrity": "sha512-cbr1P2gh7Sf81obnQIshaPs0htILit65xIC8NWAPRmuQKoDk1s8dtRzwwr3SwyQoSA/qgswP8NrZzWP9gPkScQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "dompurify": "^3.1.6"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "aem-import-rules": "^0.0.2",
+    "aem-import-rules": "^0.1.0",
     "events": "^3.3.0",
     "handlebars": "^4.7.8",
     "html-minifier-terser": "^7.2.0"

--- a/src/adapter/importAdapter.ts
+++ b/src/adapter/importAdapter.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {ImportRules, BlockRule} from 'aem-import-rules';
+import {ImportRules} from 'aem-import-rules';
 import {BuilderFileItem} from '../importBuilder.js';
 
 type AnyImportAdapter = (...args: never[]) => Promise<BuilderFileItem[]>;
@@ -19,6 +19,7 @@ export interface ImportAdapter extends Record<string, AnyImportAdapter> {
   adaptContentRemoval: () => Promise<BuilderFileItem[]>;
   adaptBlockNames: (blocks: string[]) => Promise<BuilderFileItem[]>;
   adaptCellParser: (block: string, script: string) => Promise<BuilderFileItem[]>;
+  adaptPageTransformer: (name: string, script: string) => Promise<BuilderFileItem[]>;
   adaptRules: (rules: ImportRules) => Promise<BuilderFileItem[]>;
-  adaptBlockRules: (rules: BlockRule[]) => Promise<BuilderFileItem[]>;
+  adaptImport: (rules: ImportRules) => Promise<BuilderFileItem[]>;
 }

--- a/src/assistant/findCells.ts
+++ b/src/assistant/findCells.ts
@@ -13,12 +13,11 @@
 import TemplateBuilder from '../templateBuilder.js';
 import {
   fetchChatCompletion,
-  FirefallJsonResponse,
+  FirefallResponse,
   FirefallPayload,
   firefallPayload,
+  reduceFirefallScriptResponse,
 } from '../service/firefallService.js';
-
-const javascriptRegex = /```javascript([\s\S]*?)```/g;
 
 async function findBlockCells(content: string, screenshot: string, selectors: string[], pattern: string): Promise<string[]> {
   if (!selectors.length || !pattern || !screenshot) {
@@ -31,18 +30,8 @@ async function findBlockCells(content: string, screenshot: string, selectors: st
   payload.messages.push({ role: 'user', content: [
     { type: 'text', text: prompt },
   ]});
-  const response = await fetchChatCompletion<FirefallJsonResponse>(payload);
-  const {choices = []} = response;
-  return choices.reduce((parsers, {finish_reason, message}): string[] => {
-    if (finish_reason === 'stop' && typeof message.content === 'string') {
-      const matches = message.content.matchAll(javascriptRegex);
-      [...matches].forEach((match) => {
-        const [, javascript ] = match;
-        parsers.push(javascript);
-      });
-    }
-    return parsers;
-  }, [] as string[]);
+  const response = await fetchChatCompletion<FirefallResponse>(payload);
+  return reduceFirefallScriptResponse(response);
 }
 
 export default findBlockCells;

--- a/src/assistant/generatePageTransformation.ts
+++ b/src/assistant/generatePageTransformation.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import TemplateBuilder from '../templateBuilder.js';
+import {
+  fetchChatCompletion,
+  FirefallJsonResponse,
+  FirefallPayload,
+  firefallPayload,
+} from '../service/firefallService.js';
+
+const javascriptRegex = /```javascript([\s\S]*?)```/g;
+
+async function generatePageTransformation(content: string, pattern: string): Promise<string[]> {
+  if (!pattern) {
+    return [];
+  }
+  const prompt = await TemplateBuilder.merge('/templates/prompt-transform.hbs', {pattern, content});
+  const payload: FirefallPayload = { ...firefallPayload };
+  payload.messages.push({ role: 'user', content: [
+    { type: 'text', text: prompt },
+  ]});
+  const response = await fetchChatCompletion<FirefallJsonResponse>(payload);
+  const {choices = []} = response;
+  return choices.reduce((parsers, {finish_reason, message}): string[] => {
+    if (finish_reason === 'stop' && typeof message.content === 'string') {
+      const matches = message.content.matchAll(javascriptRegex);
+      [...matches].forEach((match) => {
+        const [, javascript ] = match;
+        parsers.push(javascript);
+      });
+    }
+    return parsers;
+  }, [] as string[]);
+}
+
+export default generatePageTransformation;

--- a/src/builder/builder.ts
+++ b/src/builder/builder.ts
@@ -15,7 +15,7 @@ import {
   AsyncBuilderFunc,
 } from '../importBuilder.js';
 import ImportRuleBuilder from 'aem-import-rules/dist/rulebuilder.js';
-import {BlockRule} from 'aem-import-rules';
+import {BlockRule, TransformRule} from 'aem-import-rules';
 
 type RuleBuilder = ReturnType<typeof ImportRuleBuilder>;
 
@@ -34,12 +34,17 @@ export const buildCellParser: AsyncBuilderFunc<AdapterBuilderArgs<[BlockRule, st
   return {files: content};
 }
 
+export const buildPageTransformer: AsyncBuilderFunc<AdapterBuilderArgs<[TransformRule, string]>> = async (adapter, transformRule, script) => {
+  const content = await adapter.adaptPageTransformer(transformRule.name, script);
+  return {files: content};
+}
+
 export const buildImportRules: AsyncBuilderFunc<AdapterBuilderArgs<[RuleBuilder]>> = async (adapter, importRules) => {
   const content = await adapter.adaptRules(importRules.build());
   return {files: content};
 }
 
-export const buildImporter: AsyncBuilderFunc<AdapterBuilderArgs<[BlockRule[]]>> = async (adapter, rules) => {
-  const content = await adapter.adaptBlockRules(rules);
+export const buildImporter: AsyncBuilderFunc<AdapterBuilderArgs<[RuleBuilder]>> = async (adapter, rules) => {
+  const content = await adapter.adaptImport(rules.build());
   return {files: content};
 }

--- a/src/builder/index.ts
+++ b/src/builder/index.ts
@@ -16,6 +16,7 @@ import {
   buildContentRemoval,
   buildImporter,
   buildCellParser,
+  buildPageTransformer,
 } from './builder.js'
 
 export {
@@ -24,4 +25,5 @@ export {
   buildContentRemoval,
   buildImporter,
   buildCellParser,
+  buildPageTransformer,
 }

--- a/src/importAssistant.ts
+++ b/src/importAssistant.ts
@@ -14,6 +14,7 @@ import findMainContent from './assistant/findMainContent.js';
 import findRemovalSelectors from './assistant/findRemovalSelectors.js';
 import findBlockSelectors from './assistant/findBlocks.js';
 import findBlockCells from './assistant/findCells.js';
+import generatePageTransformation from './assistant/generatePageTransformation.js';
 
 const ImportAssistant = (document: string, screenshot: string) => {
   const escapedDocument = document.replace(/"/g, '\\"');
@@ -22,6 +23,7 @@ const ImportAssistant = (document: string, screenshot: string) => {
     findRemovalSelectors: (names: string) => findRemovalSelectors(escapedDocument, names),
     findBlockSelectors: (pattern: string) => findBlockSelectors(escapedDocument, screenshot, pattern),
     findBlockCells: (selectors: string[], pattern: string) => findBlockCells(escapedDocument, screenshot, selectors, pattern),
+    generatePageTransformation: (pattern: string) => generatePageTransformation(escapedDocument, pattern),
   }
 };
 

--- a/src/importBuilder.ts
+++ b/src/importBuilder.ts
@@ -50,8 +50,8 @@ export type AnyBuilder = {
   buildProject: AsyncBuilderFunc<string[]>;
   addCleanup: AsyncBuilderFunc<string[]>;
   addBlock: AsyncBuilderFunc<string[]>;
-  addParser: AsyncBuilderFunc<string[]>;
-  addTransformer: AsyncBuilderFunc<string[]>;
+  addCellParser: AsyncBuilderFunc<string[]>;
+  addPageTransformer: AsyncBuilderFunc<string[]>;
 };
 
 type ImportBuilderOptions = {
@@ -145,7 +145,7 @@ const ImportBuilder = ({content, adapter, rules }: ImportBuilderOptions): AnyBui
       importEvents.emit('complete');
       return {files: [...allFiles, ...importerFiles]};
     },
-    addParser: async (name, prompt) => {
+    addCellParser: async (name, prompt) => {
       const blockRule = importRules.findBlock(name);
       if (!blockRule || !prompt) {
         return {files: []};
@@ -163,7 +163,7 @@ const ImportBuilder = ({content, adapter, rules }: ImportBuilderOptions): AnyBui
       importEvents.emit('complete');
       return {files: [...parserFileItem]};
     },
-    addTransformer: async (name, prompt) => {
+    addPageTransformer: async (name, prompt) => {
       if (!name || !prompt) {
         return {files: []};
       }

--- a/src/templates/prompt-transform.hbs
+++ b/src/templates/prompt-transform.hbs
@@ -1,0 +1,12 @@
+  Problem Statement:
+    1. You are a web developer that is tasked to migrate an existing website to the Adobe Edge Delivery Services platform.
+    2. Given the following html: {{{content}}}, please write a function that will manipulate the dom under a specific element.
+    3. The function you write should be called "export default function transform(element)", where element is in the provided HTML document.
+    4. The function should make the following dom manipulations: {{pattern}}
+    6. Give me one output that will be a Javascript function that has no return value.
+  Output Javascript Requirements:
+    1. Use the querySelector and querySelectorAll methods to find elements.
+    2. All queries must be relative to the element passed in as an argument.
+    3. Do not use the "document" object in the function.
+    4. Use all the latest ES6 features.
+

--- a/src/templates/prompt-transform.hbs
+++ b/src/templates/prompt-transform.hbs
@@ -1,8 +1,9 @@
   Problem Statement:
-    1. You are a web developer that is tasked to migrate an existing website to the Adobe Edge Delivery Services platform.
+    1. You are a javascript developer that is tasked to migrate an existing website to the Adobe Edge Delivery Services platform.
     2. Given the following html: {{{content}}}, please write a function that will manipulate the dom under a specific element.
     3. The function you write should be called "export default function transform(element)", where element is in the provided HTML document.
     4. The function should make the following dom manipulations: {{pattern}}
+    5. Use the HTML to build accurate selector strings.
     6. Give me one output that will be a Javascript function that has no return value.
   Output Javascript Requirements:
     1. Use the querySelector and querySelectorAll methods to find elements.


### PR DESCRIPTION
Added a new `addTransformer` function to the import builder. This function accepts a `name` for the transformer and a `prompt` for what the transformer should do.

The goal of page transformations is to make any neccessary DOM manipulations to ensure the transformed document is in a format that can then be imported into a document. This may involve moving certain elements around or unwrapping certain elements to ensure extra markup is not leaked into the final document.

## Example

### Prompt
```
"Find the first list item element that is within a list and move all of its child nodes outside of the list. Then, remove the entire list that the list item is contained within."
```

### Generated Transformation Function
```
export default function transform(element) {
  // Find the first list item within a list relative to the passed element
  const listItem = element.querySelector('ul > li');

  // If a list item is found, proceed with the DOM manipulations
  if (listItem) {
    // Find the parent list of the found list item
    const parentList = listItem.parentNode;

    // Move all child nodes of the list item outside of the list
    while (listItem.childNodes.length > 0) {
      parentList.parentNode.insertBefore(listItem.childNodes[0], parentList);
    }

    // Remove the entire list that the list item is contained within
    parentList.parentNode.removeChild(parentList);
  }
}
```